### PR TITLE
Add container-common recommendation to prevent accumulating logs

### DIFF
--- a/mqtt-mosquitto/README.md
+++ b/mqtt-mosquitto/README.md
@@ -9,6 +9,7 @@
 
 #### Optional:
 
+- [container-common](../container-common/README.md) to prevent growing disk usage from accumulating logs
 - Port forwarding, ie. WAN -> 10.0.20.4 (TCP/1883) if needed
 
 > **Note:** Throughout this guide I'm using `VLAN 20` with gateway `10.0.20.1/24`, Mosquitto's IP will be `10.0.20.4`.


### PR DESCRIPTION
Recently my udm-pro ran into storage issues:  

Turns out the mosquitto container logs didn't rotate and accumulated to a **~6GB** log file.
Thankfully @PavelKuzub / @TRUPaC already wrote a solution for this.

This pr just adds a small recommendation to the README guide, to prevent others running into the same issue.