### PR TITLE
Fix haproxy doc

### DIFF
--- a/haproxy/21-haproxy.conflist
+++ b/haproxy/21-haproxy.conflist
@@ -1,6 +1,6 @@
 {
   "cniVersion": "0.4.0",
-  "name": "dns",
+  "name": "haproxy",
   "plugins": [
     {
       "type": "macvlan",

--- a/haproxy/21-haproxy.conflist
+++ b/haproxy/21-haproxy.conflist
@@ -1,0 +1,24 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "dns",
+  "plugins": [
+    {
+      "type": "macvlan",
+      "mode": "bridge",
+      "master": "br5",
+      "mac": "add 3 fake hex portions, replacing x's here 00:1c:b4:xx:xx:xx",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "10.0.5.3/24",
+            "gateway": "10.0.5.1"
+          }
+        ],
+        "routes": [
+          {"dst": "0.0.0.0/0"}
+        ]
+      }
+    }
+  ]
+}

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -13,10 +13,13 @@
 ## Steps
 
 1. Pull your image with `podman pull docker.io/library/haproxy`.
-1. (Optional) Configure a network by copying [21-haproxy.conflist](./21-haproxy.conflist) to /mnt/data/podman/cni/``  and update its values to reflect your environment.
-1. (If you ran the optional step above) Execute the `/mnt/data/on_boot.d/05-install-cni-plugins.sh` script to create the network
+
 1. Copy [50-haproxy.sh](./50-haproxy.sh) to `/mnt/data/on_boot.d/50-haproxy.sh`.
-1. (If you ran the optional step above) Edit `50-haproxy.sh` and change `--net=host` to `--network haproxy`
+
+1. (Optional) Configure a network
+    1. Copy [21-haproxy.conflist](./21-haproxy.conflist) to /mnt/data/podman/cni/``  and update its values to reflect your environment.
+    1. Execute the `/mnt/data/on_boot.d/05-install-cni-plugins.sh` script to create the network.
+    1. Edit `/mnt/data/on_boot.d/50-haproxy.sh` and change `--net=host` to `--network haproxy`
 1. Create a persistant directory and config for haproxy to use:
 
     ```sh

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -13,8 +13,10 @@
 ## Steps
 
 1. Pull your image with `podman pull docker.io/library/haproxy`.
-1. (Optional) Configure a network using the generic cni network [20-dns.conflist](../cni-plugins/20-dns.conflist) and update its values to reflect your environment
+1. (Optional) Configure a network by copying [21-haproxy.conflist](./21-haproxy.conflist) to /mnt/data/podman/cni/``  and update its values to reflect your environment.
+1. (If you ran the optional step above) Execute the `/mnt/data/on_boot.d/05-install-cni-plugins.sh` script to create the network
 1. Copy [50-haproxy.sh](./50-haproxy.sh) to `/mnt/data/on_boot.d/50-haproxy.sh`.
+1. (If you ran the optional step above) Edit `50-haproxy.sh` and change `--net=host` to `--network haproxy`
 1. Create a persistant directory and config for haproxy to use:
 
     ```sh

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -17,7 +17,7 @@
 1. Copy [50-haproxy.sh](./50-haproxy.sh) to `/mnt/data/on_boot.d/50-haproxy.sh`.
 
 1. (Optional) Configure a network
-    1. Copy [21-haproxy.conflist](./21-haproxy.conflist) to /mnt/data/podman/cni/``  and update its values to reflect your environment.
+    1. Copy [21-haproxy.conflist](./21-haproxy.conflist) to `/mnt/data/podman/cni/`  and update its values to reflect your environment.
     1. Execute the `/mnt/data/on_boot.d/05-install-cni-plugins.sh` script to create the network.
     1. Edit `/mnt/data/on_boot.d/50-haproxy.sh` and change `--net=host` to `--network haproxy`
 1. Create a persistant directory and config for haproxy to use:
@@ -32,6 +32,6 @@
 
 ## Upgrading Easily (if at all)
 
-1. Edit [update-haproxy.sh](./update-haproxy.sh) to use the same command you used at installation (if changed).
+1. Edit [update-haproxy.sh](./update-haproxy.sh) to use the same command you used at installation (if changed). If you added your own network config ensure you change the `--net=host` to `--network haproxy`
 2. Copy the [update-haproxy.sh](./update-haproxy.sh) to `/mnt/data/scripts`
 3. Anytime you want to update your installation, simply run `/mnt/data/scripts/update-haproxy.sh`

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -16,10 +16,14 @@
 
 1. Copy [50-haproxy.sh](./50-haproxy.sh) to `/mnt/data/on_boot.d/50-haproxy.sh`.
 
-1. (Optional) Configure a network
-    1. Copy [21-haproxy.conflist](./21-haproxy.conflist) to `/mnt/data/podman/cni/`  and update its values to reflect your environment.
-    1. Execute the `/mnt/data/on_boot.d/05-install-cni-plugins.sh` script to create the network.
-    1. Edit `/mnt/data/on_boot.d/50-haproxy.sh` and change `--net=host` to `--network haproxy`
+1. Choose network configuration - You can run either on the host network or on a seperate docker network. Running on the host network is easier but does mean you can't clash with the ports already in use on the UDM. 
+    1. If you want to run on the host network
+        1. You don't have to do anything extra to run on the host network all the instructions / scripts assume this setup.
+    1. If you want to run on a custom docker network do the following:
+        1. Setup the network - there are some instructions in the Customizations setting of the pihole instructions: https://github.com/unifi-utilities/unifios-utilities/tree/main/run-pihole#customizations
+        1. Copy [21-haproxy.conflist](./21-haproxy.conflist) to `/mnt/data/podman/cni/`  and update its values to reflect your environment.
+        1. Execute the `/mnt/data/on_boot.d/05-install-cni-plugins.sh` script to create the network.
+        1. Edit `/mnt/data/on_boot.d/50-haproxy.sh` and change `--net=host` to `--network haproxy`
 1. Create a persistant directory and config for haproxy to use:
 
     ```sh

--- a/haproxy/update-haproxy.sh
+++ b/haproxy/update-haproxy.sh
@@ -1,8 +1,10 @@
-podman pull haproxy
+IMAGE=haproxy:latest
+
+podman pull $IMAGE
 podman stop haproxy
 podman rm haproxy
 podman run -d --net=host --restart always \
   --name haproxy \
   --hostname ha.proxy \
   -v "/mnt/data/haproxy/:/usr/local/etc/haproxy/" \
-  haproxy:latest
+  $IMAGE


### PR DESCRIPTION
Updated the docs to give the examples of how  to run as both a custom network and host network.

Added the conflist required to run on a custom network. 

Updated the update script to make it easy to specify the image used but default to latest so there is no behavior change.