### PR TITLE
Add boot script for Tailscale agent, running in a container

### DIFF
--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -1,0 +1,17 @@
+# Tailscale
+Run Tailscale in a container on your Unifi Dream Machine. 
+In combination with the DNS modules, setting up a Tailscale exit node on the UDM Pro can be quite powerful. 
+Additionally, the UDM is well positioned to add a tailscale subnet router to permit remote access to the manged network. 
+
+## Prerequisites
+Follow the instructions and set up the scripts in these directories (in order) before continuing further:
+1. `on-boot-script`
+2. `container-common`
+3. `cni-plugins`
+4. (optional, but recommended if you want to set up an exit node and benefit from ad-blocking) `dns-common` followed by your favorite DNS server such as `run-pihole` or `AdguardHome`
+
+## Setup
+1. Edit `on_boot.d/20-tailscale.sh` to set an auth key, add options for `tailscale up`, or make other changes as desired.
+2. Copy `on_boot.d/20-tailscale.sh` to `/mnt/data/on_boot.d/20-tailscale.sh`.
+3. Make sure the boot script is executable with `chmod +x /mnt/data/on_boot.d/20-tailscale.sh`.
+4. Run the boot script to start the tailscale agent. You should see your new node appear in the Tailscale console. 

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -10,8 +10,14 @@ Follow the instructions and set up the scripts in these directories (in order) b
 3. `cni-plugins`
 4. (optional, but recommended if you want to set up an exit node and benefit from ad-blocking) `dns-common` followed by your favorite DNS server such as `run-pihole` or `AdguardHome`
 
-## Setup
-1. Edit `on_boot.d/20-tailscale.sh` to set an auth key, add options for `tailscale up`, or make other changes as desired.
-2. Copy `on_boot.d/20-tailscale.sh` to `/mnt/data/on_boot.d/20-tailscale.sh`.
-3. Make sure the boot script is executable with `chmod +x /mnt/data/on_boot.d/20-tailscale.sh`.
-4. Run the boot script to start the tailscale agent. You should see your new node appear in the Tailscale console. 
+## Installation
+1. Copy `on_boot.d/20-tailscale.sh` to `/mnt/data/on_boot.d/20-tailscale.sh`.
+2. Make sure the boot script is executable with `chmod +x /mnt/data/on_boot.d/20-tailscale.sh`.
+
+## Tailscale Configuration
+After installing the boot script, you will want to set up the included shell alias and check network connectivity before continuing.
+1. Run `/mnt/data/on_boot.d/20-tailscale.sh alias` to print a helpful shell alias to the terminal, inside a shell comment. 
+2. Add the alias to your running session, after which you can run `tailscale status` or `tailscale netcheck` from the host shell to make sure the running tailscale agent is healthy and has a good network connection. 
+3. `/mnt/data/on_boot.d/20-tailscale.sh status` will also perform status checks, if the alias setup isn't working for some reason.
+
+How to proceed from here is largely up to you. It is possible to authenticate by simply running `tailscale up` (if you installed the shell alias) and doing most of the rest of the configuration in the admin console. You will likely want to provide additional options to `tailscale up` to use an auth key, advertise tags or subnet routes, or other configuration.  

--- a/tailscale/on_boot.d/20-tailscale.sh
+++ b/tailscale/on_boot.d/20-tailscale.sh
@@ -1,24 +1,92 @@
 #!/bin/sh
 CONTAINER=tailscale
-# Optional: If using an authket for authenticaion, put it here
-AUTHKEY=""
-# Optional: Extra arguments passed to 'tailscale up'
-TAILSCALE_UP_ARGS=""
 
 # Starts a container for the tailscale agent.
 # There are no configuration files, and the daemon stores its state in memory
-if podman container exists ${CONTAINER}; then
-  podman start ${CONTAINER}
-else 
-  podman run -i -d --rm --net=host --name=${CONTAINER} --privileged \
-    -v "/dev/net/tun:/dev/net/tun" \
-    tailscale:tailscale \
-    tailscaled --state=mem:
-fi
+start() {
+  if podman container exists ${CONTAINER}; then
+    podman start ${CONTAINER}
+  else 
+    podman run -d --rm \
+      --net=podman \
+      --name=${CONTAINER} \
+      --privileged \
+      -v "/dev/net/tun:/dev/net/tun" \
+      tailscale/tailscale \
+      tailscaled --state=mem:
+      # Changing sysctls inside the container to support running an exit node
+    cat <<'INIT' | podman exec --privileged ${CONTAINER} /bin/sh
+echo '1' > /proc/sys/net/ipv4/ip_forward ;
+echo '1' > /proc/sys/net/ipv6/conf/all/forwarding ;
+INIT
+  fi
+}
 
-# Log in to the tailnet, using the running tailscale agent
-if [ -n $AUTHKEY ]; then
-  podman exec ${CONTAINER} tailscale up --authkey "$AUTHKEY" $TAILSCALE_UP_ARGS
-else
-  podman exec ${CONTAINER} tailscale up $TAILSCALE_UP_ARGS
-fi
+# Print the status of the tailscale connection, as well as the network status
+status() {
+  if podman container exists ${CONTAINER}; then
+    podman exec -it --privileged ${CONTAINER} tailscale status
+    podman exec -it --privileged ${CONTAINER} tailscale netcheck
+  fi
+}
+
+# Because daemon state is in memory, stopping the container removes the node
+# from the network.
+stop() {
+  podman stop ${CONTAINER}
+}
+
+# Really only useful during debugging, saves some typing at the cost of 
+# additional container creation.
+clean() {
+  podman rm ${CONTAINER} --force
+}
+
+# Print an alias to stdout to make interacting with tailscale easier, post-start
+# in case debugging needs to happen
+alias() {
+  echo "# alias tailscale='podman exec -it --privileged ${CONTAINER} tailscale '"
+}
+
+# This function shows a usage message, in case something unexpected happened
+usage() {
+  echo "Usage: $0 OPERATION"
+  echo ""
+  echo "This script manages the lifecycle of a Tailscale agent container."
+  echo "OPERATION can be one of the following commands:"
+  echo "  start     start the Tailscale agent container"
+  echo "  stop      stop the container"
+  echo "  status    get the auth status and network status of the Tailscale container"
+  echo "  clean     stop and delete the container, helpful when making config changes"
+  echo "  alias     print a helpful shell alias which can be used to interact with tailscale from the host"
+  echo "  help      show this help"
+  echo ""
+}
+
+case $1 in 
+  start)
+    start
+    ;;
+  status)
+    status
+    ;;
+  stop)
+    stop
+    ;;
+  clean)
+    stop
+    clean
+    ;;
+  alias)
+    alias
+    ;;
+  [hH-]*)
+    # This is supposed to match 'help', 'Help', '-h', etc
+    usage
+    ;;
+  *)
+    # If the script is called with no arguments, such as on startup,
+    # start the container
+    start
+    ;;
+esac

--- a/tailscale/on_boot.d/20-tailscale.sh
+++ b/tailscale/on_boot.d/20-tailscale.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+CONTAINER=tailscale
+# Optional: If using an authket for authenticaion, put it here
+AUTHKEY=""
+# Optional: Extra arguments passed to 'tailscale up'
+TAILSCALE_UP_ARGS=""
+
+# Starts a container for the tailscale agent.
+# There are no configuration files, and the daemon stores its state in memory
+if podman container exists ${CONTAINER}; then
+  podman start ${CONTAINER}
+else 
+  podman run -i -d --rm --net=host --name=${CONTAINER} --privileged \
+    -v "/dev/net/tun:/dev/net/tun" \
+    tailscale:tailscale \
+    tailscaled --state=mem:
+fi
+
+# Log in to the tailnet, using the running tailscale agent
+if [ -n $AUTHKEY ]; then
+  podman exec ${CONTAINER} tailscale up --authkey "$AUTHKEY" $TAILSCALE_UP_ARGS
+else
+  podman exec ${CONTAINER} tailscale up $TAILSCALE_UP_ARGS
+fi


### PR DESCRIPTION
I thought it would be cool to run a Tailscale exit node on my UDM Pro, along with my PiHole. That way I can have ad-free and secure internet access wherever I happen to be. I really appreciate all these boot scripts, and wanted to contribute back. This is my first time trying to run anything custom on my Unifi hardware, so there's a pretty good chance I did something wrong! Feedback is appreciated. 

I have uploaded the script to my own UDM Pro running the most recent available firmware, and it appears to work. I am submitting this PR while connected to the internet via my Tailscale exit node. 