### PR TITLE
Move cloudflare-ddns TTL config to proper location

### DIFF
--- a/cloudflare-ddns/configs/config.json
+++ b/cloudflare-ddns/configs/config.json
@@ -13,10 +13,10 @@
         "each",
         "subdomain"
       ],
-      "proxied": false,
-      "ttl": 120
+      "proxied": false
     }
   ],
+  "ttl": 120,
   "a": true,
   "aaaa": false,
   "purgeUnknownRecords": false


### PR DESCRIPTION
Current location does not match cloudflare-ddns script usage and outputs a warning `⚙️ No config detected for 'ttl' - defaulting to 300 seconds (5 minutes)`