### PR TITLE
DoTe Dockerfile Fix

### DIFF
--- a/run-pihole/custom_pihole_dote.sh
+++ b/run-pihole/custom_pihole_dote.sh
@@ -9,7 +9,7 @@ cat > "${tmpdir}/Dockerfile" <<EOF
 FROM pihole/pihole:latest
 ENV DOTE_OPTS="-s 127.0.0.1:5053"
 COPY dote /opt/dote
-RUN chmod +x /opt/dote && echo -e  "#!/bin/sh\n/opt/dote \\\$DOTE_OPTS -d\n" > /etc/cont-init.d/10-dote.sh
+RUN chmod +x /opt/dote && mkdir -p /etc/cont-init.d/ && echo -e  "#!/bin/sh\n/opt/dote \\\$DOTE_OPTS -d\n" > /etc/cont-init.d/10-dote.sh && chmod 775 /etc/cont-init.d/10-dote.sh
 EOF
 
 podman pull pihole/pihole:latest


### PR DESCRIPTION
The _run-pihole/custom\_pihole\_dote.sh_ script does not work for me as-is. First issue was due to the _/etc/cont-init.d_ dir not existing within the base pihole image:

```
STEP 1: FROM pihole/pihole:latest
STEP 2: ENV DOTE_OPTS="-s 127.0.0.1:5053"
--> Using cache 69b90c0cd6cf8d5dda2877e601f3250aeaf6546cd8bf84dcf8221d6281838e88
STEP 3: COPY dote /opt/dote
a1b2b4c7d5078e46642f6289da726f38320915199fd606063d2e2eb5490392d5
STEP 4: RUN chmod +x /opt/dote && echo -e  "#!/bin/sh\n/opt/dote \$DOTE_OPTS -d\n" > /etc/cont-init.d/10-dote.sh
/bin/bash: line 1: /etc/cont-init.d/10-dote.sh: No such file or directory
Error: error building at STEP "RUN chmod +x /opt/dote && echo -e  "#!/bin/sh\n/opt/dote \$DOTE_OPTS -d\n" > /etc/cont-init.d/10-dote.sh": error while running runtime: exit status 1
```

Fixed that via a simple `mkdir -p`. But this resulted in permission errors when s6 tried to run the _10-dote.sh_ script:

```
s6-rc: info: service s6rc-oneshot-runner: starting
s6-rc: info: service s6rc-oneshot-runner successfully started
s6-rc: info: service fix-attrs: starting
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init: starting
cont-init: info: running /etc/cont-init.d/10-dote.sh
/package/admin/s6-overlay-3.1.1.2/etc/s6-rc/scripts/cont-init: 14: /etc/cont-init.d/10-dote.sh: Permission denied
```

Fixed this with just a `chmod 775`. Could properly scope those perms better via a `chown`, but I've no idea what user or group context s6 runs within so went with the easier solution. 