### PR TITLE
Updated script to support UDM/UDMPro 2.x firmware

### DIFF
--- a/on-boot-script/remote_install.sh
+++ b/on-boot-script/remote_install.sh
@@ -61,10 +61,18 @@ udm_model() {
       echo "udmse"
       ;;
     "UniFi Dream Machine Pro")
-      echo "udmpro"
+      if test $(ubnt-device-info firmware) \< "2.0.0"; then 
+        echo "udmprolegacy"
+      else 
+        echo "udmpro"
+      fi
       ;;
     "UniFi Dream Machine")
-      echo "udm"
+      if test $(ubnt-device-info firmware) \< "2.0.0"; then 
+        echo "udmlegacy"
+      else 
+        echo "udm"
+      fi
       ;;
     "UniFi Dream Router")
       echo "udr"
@@ -160,7 +168,7 @@ depends_on curl
 ON_BOOT_D_PATH="$DATA_DIR/on_boot.d"
 
 case "$(udm_model)" in
-  udm|udmpro)
+  udmlegacy|udmprolegacy)
     echo "UDM/Pro detected, installing on-boot script..."
     depends_on podman
 
@@ -172,7 +180,7 @@ case "$(udm_model)" in
 
     echo "UDM Boot Script installed"
     ;;
-  udr|udmse)
+  udr|udmse|udm|udmpro)
     echo "UDR/UDMSE detected, installing on-boot script..."
     depends_on systemctl
 

--- a/on-boot-script/remote_install.sh
+++ b/on-boot-script/remote_install.sh
@@ -169,7 +169,8 @@ ON_BOOT_D_PATH="$DATA_DIR/on_boot.d"
 
 case "$(udm_model)" in
   udmlegacy|udmprolegacy)
-    echo "UDM/Pro detected, installing on-boot script..."
+    echo "$(ubnt-device-info model) version $(ubnt-device-info firmware) was detected"
+    echo "Installing on-boot script..."
     depends_on podman
 
     if ! install_on_boot_udm_series; then
@@ -181,7 +182,8 @@ case "$(udm_model)" in
     echo "UDM Boot Script installed"
     ;;
   udr|udmse|udm|udmpro)
-    echo "UDR/UDMSE detected, installing on-boot script..."
+    echo "$(ubnt-device-info model) version $(ubnt-device-info firmware) was detected"
+    echo "Installing on-boot script..."
     depends_on systemctl
 
     if ! install_on_boot_udr_se; then


### PR DESCRIPTION
Updated remote script to support UDM/UDM Pro 2.x firmware while preserving installation method for legacy UDM/UDM Pro 1.x firmware. 

I've tested this and it works for my UDM Pro firmware 2.4.23. 

For more details, refer to [#416](https://github.com/unifi-utilities/unifios-utilities/issues/416)