### PR TITLE
preserve bash history too

### DIFF
--- a/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 
 mkdir -p /mnt/data/.home
-if [ ! -f /mnt/data/.home/.ash_history ]; then
-  cp /root/.ash_history /mnt/data/.home/.ash_history
+
+for file in .ash_history .bash_history
+if [ ! -f /mnt/data/.home/$file ]; then
+  touch /root/$file
+  cp /root/$file /mnt/data/.home/$file
+  chown root:root /mnt/data/.home/$file
+  chmod 0600 /mnt/data/.home/$file
 fi
-ln -sf /mnt/data/.home/.ash_history /root/.ash_history
+ln -sf /mnt/data/.home/$file /root/$file
+


### PR DESCRIPTION
UDM FW 2.4.x uses gnu bash as its default shell, not busybox.

Update `on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh` to include `/root/.bash_history`