### PR TITLE
Execute 05-install-cni-plugins.sh after copying files

### DIFF
--- a/AdguardHome/README.md
+++ b/AdguardHome/README.md
@@ -19,12 +19,12 @@
 ## Steps
 
 1. Copy [05-install-cni-plugins.sh](../cni-plugins/05-install-cni-plugins.sh) to /mnt/data/on_boot.d
-1. Execute /mnt/data/on_boot.d/05-install-cni-plugins.sh
 1. On your controller, make a Corporate network with no DHCP server and give it a VLAN. For this example we are using VLAN 5.  You should confirm the bridge is created for this VLAN by running `netstat -r` otherwise the script will fail.  If it is not there, initiate a provisioning of the UDM (Controller > UDM > Config > Manage Device > Force provision).
 1. Copy [10-dns.sh](../dns-common/on_boot.d/10-dns.sh) to `/mnt/data/on_boot.d` and update its values to reflect your environment
 1. Copy [20-dns.conflist](../cni-plugins/20-dns.conflist) to `/mnt/data/podman/cni` after generating a MAC address. This will create your podman macvlan network.
-1. Execute `/mnt/data/on_boot.d/10-dns.sh`
-1. Run the AdguardHome docker container, be sure to make the directories for your persistent AdguardHome configuration.  They are mounted as volumes in the command below.
+1. Execute /mnt/data/on_boot.d/05-install-cni-plugins.sh
+3. Execute `/mnt/data/on_boot.d/10-dns.sh`
+4. Run the AdguardHome docker container, be sure to make the directories for your persistent AdguardHome configuration.  They are mounted as volumes in the command below.
 
     ```shell script
     mkdir /mnt/data/AdguardHome-Confdir


### PR DESCRIPTION
You copy the `*.conflist` files in a later step, only if you have these / this file, the `05-install-cni-plugins.sh` script will be able to create podman networks for you.