### PR TITLE
Use udmpro podman for base UDM instead of udmse

### DIFF
--- a/podman-install/on_boot.d/00-podman.sh
+++ b/podman-install/on_boot.d/00-podman.sh
@@ -31,6 +31,10 @@ case "$(udm_model)" in
   udmse|udmpro)
     DESIRED_ZIPFILE="$(udm_model)-podman-install.zip"
     ;;
+  udm)
+    # base UDM works fine with udmpro podman version, but has issues with udmse variant
+    DESIRED_ZIPFILE="udmpro-podman-install.zip"
+    ;;
   *)
     # shrug
     # udmse-podman-install.zip seems to work fine on UDM 2.4.x


### PR DESCRIPTION
See https://github.com/unifi-utilities/unifios-utilities/issues/416#issuecomment-1413489715

udmse podman install didn't work properly on base UDM. udmpro variant works without issues, so we should use that one when normal udm is detected