### PR TITLE
Update DoTE.Dockerfile to download at build time

### DIFF
--- a/run-pihole/DoTE.Dockerfile
+++ b/run-pihole/DoTE.Dockerfile
@@ -1,5 +1,13 @@
-ARG VERSION=2023.01.10
-FROM pihole/pihole:${VERSION}
-ENV DOTE_OPTS="-s 127.0.0.1:5053"
-RUN echo -e  "#!/bin/sh\ncurl -fsSLo /opt/dote https://github.com/chrisstaite/DoTe/releases/latest/download/dote_arm64\nchmod +x /opt/dote\n/opt/dote \\\$DOTE_OPTS -d\n" > /etc/cont-init.d/10-dote.sh
+ARG PIHOLE_DOCKER_TAG
 
+FROM pihole/pihole:${PIHOLE_DOCKER_TAG}
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV DOTE_OPTS="-s 127.0.0.1:5053"
+
+RUN curl -fsSLo /opt/dote https://github.com/chrisstaite/DoTe/releases/latest/download/dote_arm64 && \
+  chmod +x /opt/dote && \
+  usermod -aG pihole www-data; \
+  mkdir -p /etc/cont-init.d && \
+  echo -e "#!/bin/sh\n/opt/dote \$DOTE_OPTS -d" > /etc/cont-init.d/10-dote.sh && \
+  chmod +x /etc/cont-init.d/10-dote.sh


### PR DESCRIPTION
`dote_arm64` is now downloaded at build time instead of at first run