### PR TITLE
Update README.md with link to pihole-dote image

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Run Pi-hole on your UDM with podman.
 Also contains custom image for Pi-hole with `cloudflared`.
 
 ### PiHole with DoTe
-[![!Docker Pulls](https://img.shields.io/docker/pulls/boostchicken/pihole-dote.svg?color=green&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/u/boostchicken)
+[![!Docker Pulls](https://img.shields.io/docker/pulls/pombeirp/pihole-dote.svg?color=green&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/r/pombeirp/pihole-dote)
 
 Designed by: <https://github.com/chrisstaite/DoTe/>
 


### PR DESCRIPTION
Replace with link to a maintained `pihole-dote` Docker image, with automated builds from upstream `pihole/pihole` repository.

I worked on creating a GitHub Actions workflow to look at `pihole/pihole` releases daily, and build/push an updated version containing DoTe support automatically.

I did this before I realized that https://github.com/unifi-utilities/unifios-utilities/README.md already contained a link to an image doing the same thing. On the other hand, the image pointed to by the `README.md` is from 2021, so it doesn't seem like it is automated. Feel free to either take this MR, or close it and take the GitHub Actions workflows that I built in https://github.com/pedropombeiro/pi-hole-dote to automate the release of `boostchicken/pihole-dote` images.