### PR TITLE
Add modern-unix directory

### DIFF
--- a/modern-unix/Makefile
+++ b/modern-unix/Makefile
@@ -1,0 +1,16 @@
+RSYNC_FLAGS ?= -Ravuzh --no-o
+SCP_FLAGS ?= -O -o LogLevel=Error
+SSH_FLAGS ?= -o RemoteCommand=none -o LogLevel=error
+SSH_HOST ?= root@192.168.16.1 # IP address of the UDM in the local network
+
+.PHONY: push-config
+push-config:
+	ssh $(SSH_FLAGS) $(SSH_HOST) 'mkdir -p /data/on_boot.d /data/scripts; rm -rf /data/scripts/*.sh'
+	chmod +x ./on_boot.d/*.sh
+	rsync $(RSYNC_FLAGS) ./on_boot.d/ ./scripts/ ./settings/ $(SSH_HOST):/data/
+
+.PHONY: install-tools
+install-tools:
+	ssh $(SSH_FLAGS) $(SSH_HOST) /data/scripts/download-tools.sh
+
+.PHONY: all clean test

--- a/modern-unix/README.md
+++ b/modern-unix/README.md
@@ -1,0 +1,34 @@
+# Modern Unix tools for the UDM
+
+## Features
+
+[Modern Unix tools](https://github.com/ibraheemdev/modern-unix) to make the UDM shell more pleasant
+and modern:
+
+- [bat](https://github.com/sharkdp/bat): A `cat` clone with syntax highlighting and Git integration.
+- [bottom](https://github.com/ClementTsang/bottom): Yet another cross-platform graphical
+  process/system monitor.
+- [croc](https://github.com/schollz/croc): Easily and securely send things from one computer to another 🐊 📦
+- [duf](https://github.com/muesli/duf): A better `df` alternative.
+- [gping](https://github.com/orf/gping): `ping`, but with a graph.
+- [ncdu](https://dev.yorhel.nl/ncdu): Ncdu is a disk usage analyzer with an ncurses interface.
+- [lsd](https://github.com/Peltoche/lsd): The next gen file listing command. Backwards compatible with `ls`.
+- [xh](https://github.com/ducaale/xh): A friendly and fast tool for sending HTTP requests.
+  It reimplements as much as possible of HTTPie's excellent design, with a focus on improved performance.
+
+## Demo
+
+[![asciicast](https://asciinema.org/a/e2E1x0QilIvOgSy2N4dKSWwJ8.svg)](https://asciinema.org/a/e2E1x0QilIvOgSy2N4dKSWwJ8)
+
+## Requirements
+
+1. You have successfully setup the on boot script described [here](https://github.com/unifi-utilities/unifios-utilities/tree/main/on-boot-script)
+
+## Steps
+
+1. You may copy the files in `on_boot.d/`, `scripts/`, and `settings/` to `/data/` in the UDM, or you can
+   use the Makefile targets to copy and install the tools from a remote machine:
+
+   ```sh
+   make push-config install-tools
+   ```

--- a/modern-unix/on_boot.d/10-shell-profile.sh
+++ b/modern-unix/on_boot.d/10-shell-profile.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+## Configure shell profile
+PROFILE_SOURCE=/data/settings/profile/global.profile.d
+PROFILE_TARGET=/etc/profile.d
+
+device_info() {
+  /usr/bin/ubnt-device-info "$1"
+}
+
+# Modify login banner (motd)
+cat > /etc/motd <<EOF
+Welcome to $(device_info model)!
+(c) 2010-$(date +%Y) Ubiquiti Inc. | http://www.ui.com
+
+Model:       $(device_info model)
+Version:     $(device_info firmware)
+MAC Address: $(device_info mac)
+EOF
+
+# Extend UbiOS prompt to include useful information
+cat > /etc/profile.d/prompt.sh <<'EOF'
+UDM_NAME="$(grep -m 1 '^name:' /data/unifi-core/config/settings.yaml | awk -F: '{ gsub(/^[ \t]+|[ \t]+$/, "", $2); print tolower($2) }')"
+PROMPT_MAIN="\u@${UDM_NAME}:\w"
+
+export PS1="[UDM] ${PROMPT_MAIN}${PS1}"
+EOF
+
+# Copy all global profile scripts (for all users) from `/data/settings/profile/global.profile.d/` directory
+mkdir -p ${PROFILE_SOURCE}
+cp -rf ${PROFILE_SOURCE}/* ${PROFILE_TARGET}

--- a/modern-unix/scripts/colors.sh
+++ b/modern-unix/scripts/colors.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color

--- a/modern-unix/scripts/download-tools.sh
+++ b/modern-unix/scripts/download-tools.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPTS=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "${SCRIPTS}/colors.sh"
+
+printf "${YELLOW}%s${NC}\n" "Installing tools..."
+
+target_dir="/data/opt"
+temp_dir="$(mktemp -d)"
+
+bat_version=0.22.1
+croc_version=9.6.3
+duf_version=0.8.1
+ncdu_version=2.2.1
+lsd_version=0.23.1
+xh_version=0.18.0
+
+function download_and_extract() {
+  printf "${GREEN}%s${NC}\n" "Downloading $1..."
+  filename="$(basename "$1")"
+  wget -q "$1" -O "${temp_dir}/package.${filename##*.}"
+
+  printf "${GREEN}%s${NC}" "Extracting... "
+  if [[ ${filename##*.} == 'zip' ]]; then
+    extract_zip "$2"
+  else
+    extract_tar "$2"
+  fi
+}
+
+function extract_zip() {
+  unzip -o -j "${temp_dir}/package.zip" -d "${target_dir}" "$1"
+  rm -f "${temp_dir}/package.zip"
+}
+
+function extract_tar() {
+  if [[ $1 == *"/"* ]]; then
+    tar xzvf "${temp_dir}/package.gz" --directory="${target_dir}" --strip-components=1 "$1" --no-same-owner
+  else
+    tar xzvf "${temp_dir}/package.gz" --directory="${target_dir}" "$1" --no-same-owner
+  fi
+
+  rm -f "${temp_dir}/package.*"
+}
+
+mkdir -p "${target_dir}"
+
+archive_name="bat-v${bat_version}-aarch64-unknown-linux-gnu"
+download_and_extract "https://github.com/sharkdp/bat/releases/download/v${bat_version}/bat-v${bat_version}-aarch64-unknown-linux-gnu.tar.gz" "${archive_name}/bat"
+download_and_extract "https://github.com/ClementTsang/bottom/releases/latest/download/bottom_aarch64-unknown-linux-musl.tar.gz" btm
+download_and_extract "https://github.com/schollz/croc/releases/download/v${croc_version}/croc_${croc_version}_Linux-ARM64.tar.gz" croc
+download_and_extract "https://github.com/muesli/duf/releases/download/v${duf_version}/duf_${duf_version}_linux_arm64.tar.gz" duf
+download_and_extract "https://github.com/orf/gping/releases/latest/download/gping-aarch64-unknown-linux-musl.tar.gz" gping
+
+download_and_extract "https://dev.yorhel.nl/download/ncdu-${ncdu_version}-linux-aarch64.tar.gz" ncdu
+
+archive_name="lsd-${lsd_version}-aarch64-unknown-linux-musl"
+download_and_extract "https://github.com/Peltoche/lsd/releases/download/${lsd_version}/${archive_name}.tar.gz" "${archive_name}/lsd"
+archive_name="xh-v${xh_version}-aarch64-unknown-linux-musl"
+download_and_extract "https://github.com/ducaale/xh/releases/download/v${xh_version}/xh-v${xh_version}-aarch64-unknown-linux-musl.tar.gz" "${archive_name}/xh"
+
+rm -rf "${temp_dir}"

--- a/modern-unix/settings/profile/global.profile.d/aliases.sh
+++ b/modern-unix/settings/profile/global.profile.d/aliases.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+alias ...=../..
+alias ....=../../..
+alias .....=../../../..
+alias ......=../../../../..
+alias cp='cp -i'
+alias la='ls -lAFh'
+alias ll='ls -l'
+alias md='mkdir -p'
+alias mkcd='foo(){ mkdir -p "$1"; cd "$1" }; foo'
+alias mv='mv -i'
+alias rd=rmdir
+alias rm='rm -i'
+alias docker='podman'
+alias ls='lsd'
+alias vim='vi'

--- a/modern-unix/settings/profile/global.profile.d/opt.sh
+++ b/modern-unix/settings/profile/global.profile.d/opt.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+PATH="/data/opt:$PATH"
+export PATH


### PR DESCRIPTION
This PR adds a `modern-unix` directory to install some lightweight and useful tools (mostly written in Go and Rust) on the UDM:

<a href="https://asciinema.org/a/e2E1x0QilIvOgSy2N4dKSWwJ8" target="_blank"><img src="https://asciinema.org/a/e2E1x0QilIvOgSy2N4dKSWwJ8.svg" /></a>

NOTE: The fonts in the screencast look off, because asciinema does not support the MesloLGS font. The original looks much better :-)