### PR TITLE
ensure /etc/cni/net.d directory exists before using it

### DIFF
--- a/cni-plugins/05-install-cni-plugins.sh
+++ b/cni-plugins/05-install-cni-plugins.sh
@@ -30,7 +30,7 @@ CNI_CHECKSUM="sha256"
 # Maximum number of loops to attempt to download the plugin if required - setting a 0 or negative value will reinstalled the currently installed version (if in cache)
 MAX_TRIES=3
 
-mkdir -p "${CNI_CACHE}" "${CNI_NETD}"
+mkdir -p "${CNI_CACHE}" "${CNI_NETD}" "/etc/cni/net.d"
 # The script will attempt to use the nominated version first, and falls back to latest version if that fails
 if [ "$#" -eq 0 ]; then
   set ${CNI_PLUGIN_VER}


### PR DESCRIPTION
populate_netd is called and makes symlins into /etc/cni/net.d but the directory doesn't necessarily exist yet so need to ensure it is there before using it. fixes #505