### PR TITLE
Updates cron job file to work with /crond and /cron

### DIFF
--- a/on-boot-script/examples/udm-files/on_boot.d/25-add-cron-jobs.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/25-add-cron-jobs.sh
@@ -20,6 +20,13 @@ esac
 ## This script will re-add them on startup.
 
 cp ${DATA_DIR}/cronjobs/* /etc/cron.d/
-/etc/init.d/crond restart
+# Older UDM's had crond, so lets check if its here if so use that one, otherwise use cron
+if [ -x /etc/init.d/crond ]; then
+  /etc/init.d/crond restart
+elif [ -x /etc/init.d/cron ]; then
+  /etc/init.d/cron restart
+else
+  echo "Neither crond nor cron found."
+fi
 
 exit 0


### PR DESCRIPTION
newer versions don't have /crond anymore, so we check if crond is there if so restart it. 
if crond is not there we check for cron and restart cron if its present.

 fixes #515