### PR TITLE
Update nspawn 10-setup-network.sh to allow DNSmasq to listen to container network

### DIFF
--- a/nspawn-container/scripts/10-setup-network.sh
+++ b/nspawn-container/scripts/10-setup-network.sh
@@ -50,3 +50,9 @@ ip route add "${IPV4_IP}/32" dev "br${VLAN}.mac"
 if [ -n "${IPV6_IP}" ]; then
   ip -6 route add "${IPV6_IP}/128" dev "br${VLAN}.mac"
 fi
+
+# Make DNSMasq listen to the container network for split horizon or conditional forwarding
+if ! grep -qxF "interface=br${VLAN}.mac" /run/dnsmasq.conf.d/custom.conf; then
+  echo "interface=br${VLAN}.mac" >>/run/dnsmasq.conf.d/custom.conf
+  kill -9 "$(cat /run/dnsmasq.pid)"
+fi


### PR DESCRIPTION
The original Pi-hole script (https://github.com/unifi-utilities/unifios-utilities/blob/466ab711408b268a348d03c71713e5f1d3b44895/dns-common/on_boot.d/10-dns.sh) has a line to enable DNSmasq to listen to the container network.

This allows Pi-hole to communicate with the UDM Pro DNSmasq daemon and allow for conditional forwarding, etc.