### PR TITLE
Fix location of ResolvConf option

### DIFF
--- a/nspawn-container/examples/multicast-relay/README.md
+++ b/nspawn-container/examples/multicast-relay/README.md
@@ -80,13 +80,13 @@ Optionally, you can specify additional `multicast-relay` options in `OPTS`
 [Exec]
 Boot=on
 Capability=CAP_NET_RAW
+ResolvConf=off
 Environment=INTERFACES="br0 br50"
 Environment=OPTS=
 
 [Network]
 Private=off
 VirtualEthernet=off
-ResolvConf=off
 ```
 
 Once that file is in place, you're ready to enable the container on boot and run it.


### PR DESCRIPTION
`ResolvConf` belongs in `Exec` section, otherwise an error results. See https://www.freedesktop.org/software/systemd/man/systemd.nspawn.html#ResolvConf=