### PR TITLE
docs: nspawn network change requires reboot

### DIFF
--- a/nspawn-container/README.md
+++ b/nspawn-container/README.md
@@ -164,7 +164,7 @@ This configuration is only needed if you want to isolate the container's network
     ```sh
     chmod +x /data/on_boot.d/10-setup-network.sh
     /data/on_boot.d/10-setup-network.sh
-    machinectl start debian-custom
+    machinectl reboot debian-custom
     machinectl shell debian-custom
     ip addr show
     ping -c4 1.1.1.1


### PR DESCRIPTION
I had to use reboot for `mv-br5` to show up within the container when running `ip addr show`