### PR TITLE
fix(nspawn-container): Retry 0-setup-system.sh on failure

### DIFF
--- a/nspawn-container/scripts/0-setup-system.sh
+++ b/nspawn-container/scripts/0-setup-system.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# This script installs systemd-container if it's not installed. 
+# This script installs systemd-container if it's not installed.
 # Also links any containers from /data/custom/machines to /var/lib/machines.
+
+set -e
 
 if ! dpkg -l systemd-container | grep ii >/dev/null; then
     if ! apt -y install systemd-container debootstrap; then

--- a/nspawn-container/scripts/setup-system.service
+++ b/nspawn-container/scripts/setup-system.service
@@ -2,11 +2,13 @@
 Description=Setup custom container service
 Wants=network-online.target
 After=network-online.target
+StartLimitBurst=5
 
 [Service]
 Type=oneshot
 ExecStart=/data/on_boot.d/0-setup-system.sh
 RemainAfterExit=yes
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Other system processes can acquire a dpkg frontend lock on startup that will cause the downloaded package install to fail. The setup script continues without exiting and machinectl is not found.

This change forces the script to exit early on error, and adds 5 retries to the systemd unit at 30s intervals.

Fixes #585