### PR TITLE
Fix on-boot-script-2.x README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ at [macvlan-unifi-udr](https://github.com/whi-tw/macvlan-unifi-udr).
 
 Do this first. Enables `init.d` style scripts to run on every boot of your UDM.
 Includes examples to run `wpa-supplicant/eap-proxy` and/or `ntop-ng` on startup.
-Follow this [readme](https://github.com/unifi-utilities/unifios-utilities/blob/main/on-boot-script/README.md).
+Follow this [readme](https://github.com/unifi-utilities/unifios-utilities/blob/main/on-boot-script-2.x/README.md).
 
 **It enables complete customization of your UDM/P and fills the gap that config.gateway.json left behind.**
 


### PR DESCRIPTION
README link was pointing to `on-boot-script/README.md` instead of `on-boot-script-2.x/README.md`.