### PR TITLE
Adding install support for UniFi Dream Machine Pro Max

### DIFF
--- a/on-boot-script/remote_install.sh
+++ b/on-boot-script/remote_install.sh
@@ -52,7 +52,7 @@ depends_on() {
 
 udm_model() {
   case "$(ubnt-device-info model || true)" in
-  "UniFi Dream Machine SE")
+  "UniFi Dream Machine SE" | "UniFi Dream Machine Pro Max")
     echo "udmse"
     ;;
   "UniFi Dream Machine Pro")


### PR DESCRIPTION
The UniFi Dream Machine Pro Max is essentially an updated and improved UniFi Dream Machine SE, so I just added this to the script. This has been tested on my UniFi Dream Machine Pro Max, with the output being:

```
  _   _ ___  __  __   ___           _
 | | | |   \|  \/  | | _ ) ___  ___| |_
 | |_| | |) | |\/| | | _ \/ _ \/ _ \  _|
  \___/|___/|_|  |_| |___/\___/\___/\__|

 Execute any script when your udm system
 starts.

UniFi Dream Machine Pro Max version 4.0.21 was detected
Installing on-boot script...
Failed to disable unit: Unit file udm-boot.service does not exist.
Creating systemctl service file
Enabling UDM boot...
Created symlink /etc/systemd/system/multi-user.target.wants/udm-boot.service → /etc/systemd/system/udm-boot.service.
UDM Boot Script installed

Downloading CNI plugins script...
CNI plugins script installed
Executing CNI plugins script...
Downloading https://github.com/containernetworking/plugins/releases/download/v1.6.0/cni-plugins-linux-arm64-v1.6.0.tgz.sha256
Downloading https://github.com/containernetworking/plugins/releases/download/v1.6.0/cni-plugins-linux-arm64-v1.6.0.tgz
Pouring /data/.cache/cni-plugins/cni-plugins-linux-arm64-v1.6.0.tgz

Downloading CNI bridge script...
CNI bridge script installed
Executing CNI bridge script...
/data/on_boot.d/06-cni-bridge.sh

On boot script installation finished

You can now place your scripts in `/data/on_boot.d`
```

Running `systemctl status udm-boot` after install outputs:

```
● udm-boot.service - Run On Startup UDM
     Loaded: loaded (/etc/systemd/system/udm-boot.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Tue 2024-11-26 17:17:56 GMT; 11min ago
    Process: 1723073 ExecStart=bash -c mkdir -p /data/on_boot.d && find -L /data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- bash -c 'if test -x "$0"; then echo "udm-boot.service: r>
        CPU: 9ms

Nov 26 17:17:56 gateway systemd[1]: Starting Run On Startup UDM...
Nov 26 17:17:56 gateway systemd[1]: udm-boot.service: Succeeded.
Nov 26 17:17:56 gateway systemd[1]: Started Run On Startup UDM.
```
