### PR TITLE
Pointing the sample scripts to the right branch

### DIFF
--- a/nspawn-container/README.md
+++ b/nspawn-container/README.md
@@ -112,7 +112,7 @@ This configuration is only needed if you want to isolate the container's network
 
     ```sh
     mkdir -p /data/on_boot.d && cd /data/on_boot.d
-    curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/nspawn/nspawn-container/scripts/10-setup-network.sh
+    curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/main/nspawn-container/scripts/10-setup-network.sh
     vim 10-setup-network.sh
     ```
 
@@ -186,7 +186,7 @@ When the firmware is updated, `/data` (which contains our container storage) and
 
     ```sh
     mkdir -p /data/on_boot.d && cd /data/on_boot.d
-    curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/nspawn/nspawn-container/scripts/0-setup-system.sh
+    curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/main/nspawn-container/scripts/0-setup-system.sh
     chmod +x /data/on_boot.d/0-setup-system.sh
     ```
     

--- a/nspawn-container/interactive_setup.sh
+++ b/nspawn-container/interactive_setup.sh
@@ -175,7 +175,7 @@ cd /data/on_boot.d
 if [ -f "$file" ] ; then
     rm "$file"
 fi
-curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/nspawn/nspawn-container/scripts/10-setup-network.sh
+curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/main/nspawn-container/scripts/10-setup-network.sh
 chmod +x 10-setup-network.sh
 
 cat <<EOF > /etc/systemd/nspawn/"$container_name".nspawn
@@ -232,7 +232,7 @@ function setup_persistence() {
 #### Configure Persistence Across Firmware Updates
 echo "Configuring Persistence Across Firmware Updates" 
 cd /data/on_boot.d
-curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/nspawn/nspawn-container/scripts/0-setup-system.sh
+curl -LO https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/main/nspawn-container/scripts/0-setup-system.sh
 chmod +x 0-setup-system.sh
 
 mv 0-setup-system.sh 02-setup-system.sh


### PR DESCRIPTION
The existing documentation and the sample script were pointing to the old branch (nspawn) instead to point to main. 