### PR TITLE
Add 4.0 support for on_boot example 25-add-cron-jobs

### DIFF
--- a/on-boot-script/examples/udm-files/on_boot.d/25-add-cron-jobs.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/25-add-cron-jobs.sh
@@ -11,6 +11,9 @@ case "$(ubnt-device-info firmware || true)" in
 3*)
     DATA_DIR="/data"
     ;;
+4*)
+  DATA_DIR="/data"
+  ;;
 *)
     echo "ERROR: No persistent storage found." 1>&2
     exit 1


### PR DESCRIPTION
Basically, follow-up to the issue #602 with pull request on #603 