### PR TITLE
Allow bootscript to install on UniFi Dream Wall

### DIFF
--- a/on-boot-script/remote_install.sh
+++ b/on-boot-script/remote_install.sh
@@ -52,6 +52,9 @@ depends_on() {
 
 udm_model() {
   case "$(ubnt-device-info model || true)" in
+  "UniFi Dream Wall")
+    echo "udw"
+    ;;
   "UniFi Dream Machine SE")
     echo "udmse"
     ;;
@@ -176,7 +179,7 @@ udmlegacy | udmprolegacy)
 
   echo "UDM Boot Script installed"
   ;;
-udr | udmse | udm | udmpro)
+udr | udmse | udm | udmpro | udw)
   echo "$(ubnt-device-info model) version $(ubnt-device-info firmware) was detected"
   echo "Installing on-boot script..."
   depends_on systemctl


### PR DESCRIPTION
There is no legacy Dream Wall, I tested this modification on my dream wall and it install fine.