### PR TITLE
Add support for UniFi Dream Router 7 (UDR7)

### DIFF
--- a/on-boot-script-2.x/remote_install.sh
+++ b/on-boot-script-2.x/remote_install.sh
@@ -72,6 +72,9 @@ udm_model() {
   "UniFi Dream Router")
     echo "udr"
     ;;
+  "UniFi Dream Router 7")
+    echo "udr"
+    ;;
   "UniFi Dream Machine Pro Max")
     echo "udmpromax"
     ;;


### PR DESCRIPTION
Map the "UniFi Dream Router 7" model string to the existing "udr" identifier to ensure compatibility with the on-boot script installation process.